### PR TITLE
Store migrated keys in database

### DIFF
--- a/tests/inside/test_migrate.py
+++ b/tests/inside/test_migrate.py
@@ -7,24 +7,27 @@ key1 = '1437737998_1507635670.jpg'
 key2 = '1437738073_375759438.jpg'
 
 
+sql_results = (
+    [
+        None,  # _init_v5_database
+        None,  # _init_bucket_database
+        Mock(fetchone=Mock(return_value={'count': 2})),
+        [{'filename': key1}, {'filename': key2}]] +
+    8 * [Mock(fetchone=Mock(return_value={'count': 0}))] +  # _is_migrated
+    8 * [None] +  # _set_migrated
+    [
+        Mock(fetchone=Mock(return_value={'count': 2})),
+        [{'filename': key1}, {'filename': key2}]] +
+    8 * [Mock(fetchone=Mock(return_value={'count': 1}))])  # _is_migrated
+
+
 @patch(
     'c2corg_images.scripts.migrate.create_engine',
     return_value=Mock(
         connect=Mock(
             return_value=Mock(
                 execute=Mock(
-                    side_effect=[
-                        None,
-                        Mock(
-                            fetchone=Mock(
-                                return_value={'count': 2})),
-                        [{'filename': key1},
-                         {'filename': key2}],
-                        Mock(
-                            fetchone=Mock(
-                                return_value={'count': 2})),
-                        [{'filename': key1},
-                         {'filename': key2}]])))))
+                    side_effect=sql_results)))))
 def test_migrate(create_engine):
     migrator = Migrator()
     migrator.execute()


### PR DESCRIPTION
Reduce the number of requests on S3 bucket during incremental migration.