### PR TITLE
Docker fixups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,10 @@ RUN rm -fr .cache \
 COPY scripts scripts
 COPY tests tests
 
-RUN mkdir -p /var/www/incoming /var/www/active /var/www/temp && \
-    chown www-data:www-data /var/www/incoming /var/www/active /var/www/temp
-
 EXPOSE 8080
-USER www-data
-CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:8080", "c2corg_images:app"]
+
+COPY /docker-entrypoint.sh /
+COPY /docker-entrypoint.d/* /docker-entrypoint.d/
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["gunicorn", "-w", "4", "-u", "www-data", "-g", "www-data", "-b", "0.0.0.0:8080", "c2corg_images:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,13 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/50no-install-recommends
 RUN echo 'APT::Install-Suggests "0";' > /etc/apt/apt.conf.d/50no-install-suggests
 
+WORKDIR /var/www/
+
+COPY requirements.txt ./
+COPY requirements_pip.txt ./
+COPY setup.py ./
+COPY c2corg_images c2corg_images
+
 RUN apt-get update \
  && apt-get -y upgrade \
  && apt-get install -y \
@@ -19,22 +26,12 @@ RUN apt-get update \
     libpq5 \
     libpq-dev \
     python3-dev \
-    gcc
-
-WORKDIR /var/www/
-
-COPY requirements.txt ./
-COPY requirements_pip.txt ./
-COPY setup.py ./
-COPY c2corg_images c2corg_images
-
-RUN pip3 install -r requirements_pip.txt && \
-    pip  install -r requirements.txt && \
-    pip  install . && \
-    py3compile -f . && \
-    rm -fr .cache
-
-RUN rm -fr .cache \
+    gcc \
+ && pip3 install -r requirements_pip.txt \
+ && pip  install -r requirements.txt \
+ && pip  install . \
+ && py3compile -f . \
+ && rm -fr .cache \
  && apt-get -y purge \
     python3-dev \
     libpq-dev \

--- a/docker-entrypoint.d/00-create-dirs.sh
+++ b/docker-entrypoint.d/00-create-dirs.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+for folder in "${TEMP_FOLDER}" "${INCOMING_FOLDER}" "${ACTIVE_FOLDER}"; do
+  test -n "${folder}" || exit 1
+  mkdir -p "${folder}" || exit 1
+  chown www-data:www-data "${folder}" || exit 1
+done

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+DIR=/docker-entrypoint.d
+
+if test -d "$DIR"
+then
+  /bin/run-parts --verbose --regex '\.sh$' "$DIR" || exit 1
+fi
+
+exec "$@"


### PR DESCRIPTION
This allows the container to work on a pristine environment, without having to manually create the working directories.

Also, brings down the image size from 230MB to 142MB.